### PR TITLE
Fix: Time was updating on previous task instead of current task #2170

### DIFF
--- a/project.py
+++ b/project.py
@@ -1589,7 +1589,7 @@ class Project:
             TimesheetLine.create({
                 'employee': request.nereid_user.employee.id,
                 'hours': hours,
-                'work': task.id
+                'work': task.work.id
             })
 
         # Send the email since all thats required is done


### PR DESCRIPTION
- This patch includes changes in passing task.work.id in TimesheetLine
  work field replacing task.id

Task ID: project-7/task-2170
