### PR TITLE
Time marked on other task instead of current task by an employee #2216

### DIFF
--- a/project.py
+++ b/project.py
@@ -1846,7 +1846,7 @@ class Project:
             TimesheetLine.create({
                 'employee': request.nereid_user.employee.id,
                 'hours': request.form['hours'],
-                'work': task.id
+                'work': task.work.id,
             })
 
         flash("Time has been marked on task %s" % task.name)


### PR DESCRIPTION
- This patch passes task.work.id in TimesheetLine instead of task.id

Task ID: project-7/task-2216
Issue ID: 338001
