### PR TITLE
Fixed user filter selection in tasks #5221

### DIFF
--- a/templates/!project/project/task-list-kanban.jinja
+++ b/templates/!project/project/task-list-kanban.jinja
@@ -41,8 +41,8 @@
         <input type="hidden" name="state" value="{{ state_filter }}"/>
         <div class="input-append">
           <select name="user" class="select-user">
+            <option value="">Anyone</option>
             <optgroup label="Assigned to:">
-              <option value="">Anyone</option>
               {% for member in project.members %}
                 {% if not member.user.id == request.nereid_user.id %}
                   <option value="{{ member.user.id }}"

--- a/templates/!project/project/task-list.jinja
+++ b/templates/!project/project/task-list.jinja
@@ -43,8 +43,8 @@
         {% endif %}
         <div class="input-append">
           <select name="user" class="select-user">
+            <option value="">Anyone</option>
             <optgroup label="Assigned to:">
-              <option value="">Anyone</option>
               {% for member in project.members %}
                 {% if not member.user.id == request.nereid_user.id %}
                   <option value="{{ member.user.id }}"


### PR DESCRIPTION
The selection used to show "Anyone" inside optgroup "Assigned to".
Now showing "Anyone" above it.
