### PR TITLE
Fixed issue for Delete task button on task page

### DIFF
--- a/templates/!project/project/task.jinja
+++ b/templates/!project/project/task.jinja
@@ -249,7 +249,7 @@
   <a href="" rel="tooltip" title="{{ participant.display_name }}"><img src="{{ participant.get_profile_picture(size="30") }}" alt="{{ participant.display_name }}" class="img-rounded"/></a>
   {% endfor %}
 
-{% if request.nereid_user.is_admin_of_project(task) %}
+{% if current_user.is_admin_of_project(task.parent) %}
 <hr>
 <h4>Delete task
 


### PR DESCRIPTION
The template was checking if the current user is admin of
the current project. Instead of sending project as an argument
it was sending the task.
