### PR TITLE
Fix kanban view progress bar

### DIFF
--- a/ng-app/app/views/tasks-kanban.html
+++ b/ng-app/app/views/tasks-kanban.html
@@ -1,3 +1,4 @@
+<md-progress-linear ng-if="loadingTasks" md-mode="indeterminate"></md-progress-linear>
 <div class="kanban-container" layout="row">
 
   <div flex="22" ng-repeat="progressState in progressStates" layout-margin>
@@ -12,5 +13,3 @@
   </div>
 
 </div>
-
-<md-progress-linear ng-if="loadingTasks" md-mode="indeterminate"></md-progress-linear>


### PR DESCRIPTION
Progress bar is not visible under the kanban view, so putting it on the top,
which fixes the problem.
