### PR TITLE
Freeze angular material version

### DIFF
--- a/ng-app/bower.json
+++ b/ng-app/bower.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "angular": "~1.3.0",
     "ui-router": "~0.2.12",
-    "angular-material": "~0.9.0",
+    "angular-material": "0.9.4",
     "mdi": "~1.0.0",
     "angular-mocks": "~1.3.13",
     "angular-hotkeys": "chieffancypants/angular-hotkeys#~1.4.5",


### PR DESCRIPTION
The latest version of angular material causes problems with md-tab; it
calls false md-tab-selected event.
